### PR TITLE
Removed versioning from the .so names

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,9 +35,4 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_HEADERS = txc_dxtn.pc
 endif
 
-# versioninfo:
-#   - compatible interface change: c:r:a -> c+1:0:a+1
-#   - incompatible interface change: c:r:a -> c+1:0:0
-#   - internal change: c:r:a -> c:r+1:a
-
 EXTRA_DIST = README.txt autogen.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ endif
 if ENABLE_LIB
 lib_LTLIBRARIES = libtxc_dxtn.la
 libtxc_dxtn_la_SOURCES = s2tc_algorithm.cpp s2tc_libtxc_dxtn.cpp s2tc_common.h s2tc_algorithm.h txc_dxtn.h s2tc_license.h
-libtxc_dxtn_la_LDFLAGS = -versioninfo 0:0:0 -nodefaultlibs
+libtxc_dxtn_la_LDFLAGS = -avoid-version -nodefaultlibs
 libtxc_dxtn_la_LIBADD = -lm
 libtxc_dxtn_la_CFLAGS = -fvisibility=hidden -Wold-style-definition -Wstrict-prototypes -Wsign-compare -Wdeclaration-after-statement
 library_includedir = $(includedir)


### PR DESCRIPTION
This was added to @openSUSE in reference with https://bugzilla.novell.com/show_bug.cgi?id=890953.